### PR TITLE
Pass timeout errors through onError rather than throwing.

### DIFF
--- a/alameda.js
+++ b/alameda.js
@@ -1050,7 +1050,7 @@ var requirejs, require, define;
                 });
                 err = new Error('Timeout for modules: ' + noLoads);
                 err.requireModules = noLoads;
-                throw err;
+                req.onError(err);
             } else if (loadCount || reqDefs.length) {
                 //Something is still waiting to load. Wait for it, but only
                 //if a timeout is not already in effect.


### PR DESCRIPTION
Timeout errors are getting thrown instead of reported to onError.  This is for my happy unit test driver that likes to hear about require() errors directly rather than figuring it out from window.onerror.
