### PR TITLE
Support for named define() in package

### DIFF
--- a/alameda.js
+++ b/alameda.js
@@ -280,6 +280,12 @@ var requirejs, require, define;
             // Not our anon module, stop.
             break;
           }
+        } else if (anonId && anonId.indexOf(queue[i][0]) === 0) {
+          // Exception for modules that define their name explicitly and
+          // defined name coincides with package name
+          queue[i] = queue[i].slice(1);
+          queue[i].unshift(anonId);
+          anonId = undef;
         }
         args = queue.shift();
         id = args[0];

--- a/tests/all.js
+++ b/tests/all.js
@@ -24,3 +24,4 @@ doh.registerUrl("hasOwnPropertyTests", "../hasOwnProperty/hasOwnProperty.html");
 doh.registerUrl("dataMainBaseUrl", "../dataMainBaseUrl/dataMainBaseUrl.html");
 doh.registerUrl("emptyRequire", "../emptyRequire/emptyRequire.html");
 doh.registerUrl("promiseRequire", "../promiseRequire/promiseRequire.html");
+doh.registerUrl("packageWithNamedDefine", "../packageWithNamedDefine/packageWithNamedDefine.html");

--- a/tests/packageWithNamedDefine/packageName/src/packageName.js
+++ b/tests/packageWithNamedDefine/packageName/src/packageName.js
@@ -1,0 +1,7 @@
+define('localModule', function(){
+  return 'xyz';
+});
+
+define('packageName', ['localModule'], function(localModule){
+  return localModule;
+});

--- a/tests/packageWithNamedDefine/packageWithNamedDefine.html
+++ b/tests/packageWithNamedDefine/packageWithNamedDefine.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>alameda: packageWithNamedDefine Test</title>
+    <script type="text/javascript" src="../doh/runner.js"></script>
+    <script type="text/javascript" src="../doh/_browserRunner.js"></script>
+    <script type="text/javascript" src="../../alameda.js"></script>
+    <script type="text/javascript">
+        requirejs.config({
+            packages: [{
+                name: 'packageName',
+                main: 'packageName',
+                location: 'packageName/src'
+            }]
+        });
+
+        require(['packageName'], function(packageName){
+            doh.register(
+                'packageWithNamedDefine',
+                [
+                    function packageWithNamedDefine(t){
+                        t.is('xyz', packageName);
+                    }
+                ]
+            );
+            doh.run();
+        });
+    </script>
+</head>
+<body>
+    <h1>alameda: packageWithNamedDefine Test</h1>
+
+    <p>Test define with module name when configured via packages. More info:
+    <a href="https://github.com/requirejs/alameda/issues/22">22</a>.</p>
+
+    <p>Check console for messages</p>
+</body>
+</html>


### PR DESCRIPTION
Added support for tricky situation when package configured via `packages` calls `define()` with its own name specified explicitly.

Fixes #22