### PR TITLE
fix an exception under async loads

### DIFF
--- a/alameda.js
+++ b/alameda.js
@@ -28,6 +28,8 @@ var requirejs, require, define;
     return;
   }
 
+  var asap = Promise.resolve(undefined);
+
   // Could match something like ')//comment', do not lose the prefix to comment.
   function commentReplace(match, singlePrefix) {
     return singlePrefix || '';
@@ -702,7 +704,16 @@ var requirejs, require, define;
 
           script.src = url;
 
-          document.head.appendChild(script);
+          // If the script is cached, IE10 executes the script body and the
+          // onload handler synchronously here.  That's a spec violation,
+          // so be sure to do this asynchronously.
+          if (document.documentMode === 10) {
+            asap.then(function() {
+              document.head.appendChild(script);
+            });
+          } else {
+            document.head.appendChild(script);
+          }
         };
 
     function callPlugin(plugin, map, relName) {

--- a/alameda.js
+++ b/alameda.js
@@ -683,14 +683,14 @@ var requirejs, require, define;
           script.addEventListener('error', function () {
             loadCount -= 1;
             var err,
-              pathConfig = getOwn(config.paths, id),
-              d = getOwn(deferreds, id);
+              pathConfig = getOwn(config.paths, id);
             if (pathConfig && Array.isArray(pathConfig) &&
                 pathConfig.length > 1) {
               script.parentNode.removeChild(script);
               // Pop off the first array value, since it failed, and
               // retry
               pathConfig.shift();
+              var d = getDefer(id);
               d.map = makeMap(id);
               load(d.map);
             } else {

--- a/alameda.js
+++ b/alameda.js
@@ -698,6 +698,7 @@ var requirejs, require, define;
               pathConfig.shift();
               var d = getDefer(id);
               d.map = makeMap(id);
+	      d.map.url = req.nameToUrl(id);
               load(d.map);
             } else {
               err = new Error('Load failed: ' + id + ': ' + script.src);
@@ -975,11 +976,13 @@ var requirejs, require, define;
     }
 
     main = function (name, deps, factory, errback, relName) {
-      // Only allow main calling once per module.
-      if (name && hasProp(calledDefine, name)) {
-        return;
+      if (name) {
+        // Only allow main calling once per module.
+        if (hasProp(calledDefine, name)) {
+          return;
+        }
+        calledDefine[name] = true;
       }
-      calledDefine[name] = true;
 
       var d = getDefer(name);
 

--- a/alameda.js
+++ b/alameda.js
@@ -484,9 +484,9 @@ var requirejs, require, define;
         name = d.map.id;
 
       try {
-         ret = d.factory.apply(defined[name], d.values);
+        ret = context.execCb(name, d.factory, d.values, defined[name]);
       } catch(err) {
-         return reject(d, err);
+        return reject(d, err);
       }
 
       if (name) {
@@ -1193,7 +1193,10 @@ var requirejs, require, define;
       waiting: waiting,
       config: config,
       deferreds: deferreds,
-      req: req
+      req: req,
+      execCb: function execCb(name, callback, args, exports) {
+        return callback.apply(exports, args);
+      }
     };
 
     contexts[contextName] = context;

--- a/alameda.js
+++ b/alameda.js
@@ -320,7 +320,11 @@ var requirejs, require, define;
           // deps arg is the module name, and second arg (if passed)
           // is just the relName.
           // Normalize module name, if it contains . or ..
-          name = makeMap(deps, relName, true).id;
+          var map = makeMap(deps, relName, true);
+          name = map.id;
+          if (hasProp(waiting, name)) {
+	      callDep(map, relName);
+          }
           if (!hasProp(defined, name)) {
             throw new Error('Not loaded: ' + name);
           }

--- a/tests/all.js
+++ b/tests/all.js
@@ -1,6 +1,7 @@
 
 doh.registerUrl("simple", "../simple.html");
 doh.registerUrl("defineDouble", "../defineDouble/defineDouble.html");
+doh.registerUrl("defineAndRequire", "../defineAndRequire/defineAndRequire.html");
 doh.registerUrl("moduleConfig", "../moduleConfig/moduleConfig.html");
 doh.registerUrl("mapConfig", "../mapConfig/mapConfig.html");
 doh.registerUrl("mapConfigStar", "../mapConfig/mapConfigStar.html");

--- a/tests/defineAndRequire/defineAndRequire.html
+++ b/tests/defineAndRequire/defineAndRequire.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>alameda: Define And Require Test</title>
+    <script src="../doh/runner.js"></script>
+    <script src="../doh/_browserRunner.js"></script>
+    <script src="../../alameda.js"></script>
+    <script>
+        define('a', [], function () {
+            return 1;
+        });
+        var a = require('a');
+        doh.register('defineAndRequire', [function defineAndRequire(t) {
+            t.is(1, a);
+        }]);
+        doh.run();
+    </script>
+</head>
+<body>
+    <h1>alameda: Define And Require Test</h1>
+    <p>Make sure we can define and require immediately.</p>
+    <p>Check console for messages</p>
+</body>
+</html>


### PR DESCRIPTION
Hi @jrburke!  I'm trying to replace our RequireJS runtime with Alameda and ran into an exception.  I don't fully understand the reproduction (hence no test case), but I think it involved an async load after a module load failed.

Maybe you'll be able to see what scenario causes this code to fail.  (Specifically, deferreds[id] does not exist, and getOwn returns false in that case, causing `d.map` to be undefined in the `load(d.map)` call.)