### PR TITLE
fix an exception under async loads

### DIFF
--- a/alameda.js
+++ b/alameda.js
@@ -683,14 +683,14 @@ var requirejs, require, define;
           script.addEventListener('error', function () {
             loadCount -= 1;
             var err,
-              pathConfig = getOwn(config.paths, id),
-              d = getOwn(deferreds, id);
+              pathConfig = getOwn(config.paths, id);
             if (pathConfig && Array.isArray(pathConfig) &&
                 pathConfig.length > 1) {
               script.parentNode.removeChild(script);
               // Pop off the first array value, since it failed, and
               // retry
               pathConfig.shift();
+              var d = getDefer(id);
               d.map = makeMap(id);
               load(d.map);
             } else {


### PR DESCRIPTION
This is a resubmission of PR #26 because I screwed up the first time.

Hi @jrburke! I'm trying to replace our RequireJS runtime with Alameda and ran into an exception. I don't fully understand the reproduction (hence no test case), but I think it involved an async load after a module load failed.

Maybe you'll be able to see what scenario causes this code to fail. (Specifically, deferreds[id] does not exist, and getOwn returns false in that case, causing d.map to be undefined in the load(d.map) call.)