### PR TITLE
Optimizations

### DIFF
--- a/alameda.js
+++ b/alameda.js
@@ -98,7 +98,7 @@ var requirejs, require, define;
   function newContext(contextName) {
     var req, main, makeMap, callDep, handlers, checkingLater, load, context,
       defined = Object.create(null),
-      waiting = {},
+      waiting = Object.create(null),
       config = {
         // Defaults. Do not set a default for map
         // config to speed up normalize(), which
@@ -285,7 +285,7 @@ var requirejs, require, define;
         id = args[0];
         i -= 1;
 
-        if (!(id in defined) && !hasProp(waiting, id)) {
+        if (!(id in defined) && !(id in waiting)) {
           if (hasProp(deferreds, id)) {
             main.apply(undef, args);
           } else {
@@ -714,7 +714,7 @@ var requirejs, require, define;
         name = map.id,
         shim = config.shim[name];
 
-      if (hasProp(waiting, name)) {
+      if (name in waiting) {
         args = waiting[name];
         delete waiting[name];
         main.apply(undef, args);

--- a/alameda.js
+++ b/alameda.js
@@ -97,7 +97,7 @@ var requirejs, require, define;
 
   function newContext(contextName) {
     var req, main, makeMap, callDep, handlers, checkingLater, load, context,
-      defined = {},
+      defined = Object.create(null),
       waiting = {},
       config = {
         // Defaults. Do not set a default for map
@@ -285,7 +285,7 @@ var requirejs, require, define;
         id = args[0];
         i -= 1;
 
-        if (!hasProp(defined, id) && !hasProp(waiting, id)) {
+        if (!(id in defined) && !hasProp(waiting, id)) {
           if (hasProp(deferreds, id)) {
             main.apply(undef, args);
           } else {
@@ -443,12 +443,12 @@ var requirejs, require, define;
       };
 
       req.defined = function (id) {
-        return hasProp(defined, makeMap(id, relName, true).id);
+        return makeMap(id, relName, true).id in defined;
       };
 
       req.specified = function (id) {
         id = makeMap(id, relName, true).id;
-        return hasProp(defined, id) || hasProp(deferreds, id);
+        return id in defined || hasProp(deferreds, id);
       };
 
       return req;
@@ -795,7 +795,7 @@ var requirejs, require, define;
 
       if (prefix) {
         prefix = normalize(prefix, relName, applyMap);
-        plugin = hasProp(defined, prefix) && defined[prefix];
+        plugin = (prefix in defined) && defined[prefix];
       }
 
       // Normalize according

--- a/alameda.js
+++ b/alameda.js
@@ -111,10 +111,10 @@ var requirejs, require, define;
         shim: {},
         config: {}
       },
-      mapCache = {},
+      mapCache = Object.create(null),
       requireDeferreds = [],
       deferreds = Object.create(null),
-      calledDefine = {},
+      calledDefine = Object.create(null),
       calledPlugin = {},
       loadCount = 0,
       startTime = (new Date()).getTime(),
@@ -319,7 +319,7 @@ var requirejs, require, define;
           // is just the relName.
           // Normalize module name, if it contains . or ..
           name = makeMap(deps, relName, true).id;
-          if (!hasProp(defined, name)) {
+          if (!(name in defined)) {
             throw new Error('Not loaded: ' + name);
           }
           return defined[name];
@@ -789,7 +789,7 @@ var requirejs, require, define;
       prefix = parts[0];
       name = parts[1];
 
-      if (!prefix && hasProp(mapCache, cacheKey)) {
+      if (!prefix && (cacheKey in mapCache)) {
         return mapCache[cacheKey];
       }
 
@@ -962,7 +962,7 @@ var requirejs, require, define;
 
     main = function (name, deps, factory, errback, relName) {
       // Only allow main calling once per module.
-      if (name && hasProp(calledDefine, name)) {
+      if (name && (name in calledDefine)) {
         return;
       }
       calledDefine[name] = true;
@@ -1084,7 +1084,7 @@ var requirejs, require, define;
       }
 
       // Since config changed, mapCache may not be valid any more.
-      mapCache = {};
+      mapCache = Object.create(null);
 
       // Make sure the baseUrl ends in a slash.
       if (cfg.baseUrl) {


### PR DESCRIPTION
Since Alameda requires ES5, hasProp for internal data structures is superfluous - we need simply to use `in` and direct property access.  This is a microoptimization - I have not measured it but hasProp and eachProp were showing up as nontrivial costs in the Chrome timeline and profiler, and they're not necessary against the internal data structures.
